### PR TITLE
[Fix bug]当游戏tick freeze时, 实体会抽搐

### DIFF
--- a/src/main/java/mypals/ml/mixin/client/optionalTicking/WorldRenderFreeze.java
+++ b/src/main/java/mypals/ml/mixin/client/optionalTicking/WorldRenderFreeze.java
@@ -47,7 +47,7 @@ public abstract class WorldRenderFreeze {
                                        float tickDelta, MatrixStack matrices,
                                        VertexConsumerProvider vertexConsumers, Operation<Void> original,
                                        @Local(argsOnly = true) RenderTickCounter renderTickCounter) {
-        tickDelta = renderTickCounter.getTickDelta(!YetAnotherCarpetAdditionRules.stopTickingEntities || !MinecraftClient.getInstance().world.getTickManager().shouldTick());
+        tickDelta = YetAnotherCarpetAdditionRules.stopTickingEntities? 1.0F : tickDelta;
         original.call(instance, entity, cameraX, cameraY, cameraZ, tickDelta, matrices, vertexConsumers);
     }
 


### PR DESCRIPTION
## 复现方法
客户端安装此mod, 在游戏中`/tick freeze`, 在空中丢出一个掉落物.

## 现象
物品稍微抽搐抖动, 在`/tick step`后抖动更加明显

## 如何修复?

排查代码后发现[客户端mixin](https://github.com/hotpad100c/yetanothercarpetaddition/blob/main/src/main/java/mypals/ml/mixin/client/optionalTicking/WorldRenderFreeze.java)下的这段代码造成的问题
```java
tickDelta = renderTickCounter.getTickDelta(!YetAnotherCarpetAdditionRules.stopTickingEntities || !MinecraftClient.getInstance().world.getTickManager().shouldTick());
original.call(instance, entity, cameraX, cameraY, cameraZ, tickDelta, matrices, vertexConsumers);
```
经过调试和 MC 源码研究 ,  发现:
1. 游戏在 freeze 时 tickDelta 始终返回 1.0F. 
```java
// RenderTickCounter.Dynamic.class
        public float getTickDelta(boolean bl) {
            if (!bl && this.tickFrozen) {
                return 1.0F;
            } else {
                return this.paused ? this.tickDeltaBeforePause : this.tickDelta;
            }
        }
```
2. 非freeze时, `RenderTickCounter.getTickDelta(true)`和`RenderTickCounter.getTickDelta(false)`的返回值一致
3. 第二点是造成此问题的原因


**所以修复方法为**:当启用`stopTickingEntities`时, 令tickDelta始终返回 `1.0F`.